### PR TITLE
Add the README as module documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ arguments.
 
 Example:
 
-```rust
+```rust,ignore
 let (query, args) = query_args!(
     r"
     SELECT location, time, report
@@ -32,7 +32,7 @@ As can be seen from the example above, shorthand field initialization is also al
 For `INSERT`'s a special syntax is supported, which helps to avoid mismatches
 between the list of column names and the values:
 
-```rust
+```rust,ignore
 let (query, args) = query_args!(
     r"
     INSERT INTO weather_reports

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{


### PR DESCRIPTION
I included the README as module documentation so that it shows up on docs.rs. Since the tests require more setup, I disabled them.

cc @LHolten
