### PR TITLE
Module docs as readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --all-features --verbose
+
+  readme:
+    name: Check if the README is up to date.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install cargo-rdme
+      - run: cargo rdme --check

--- a/README.md
+++ b/README.md
@@ -1,14 +1,33 @@
 # PostgreSQL named arguments
 
+<!-- cargo-rdme start -->
+
 This library allows one to use named arguments in PostgreSQL queries. This
 library is especially aimed at supporting
 [rust-postgres](https://github.com/sfackler/rust-postgres). A macro is provided
 to rewrite queries with named arguments, into a query and its positional
 arguments.
 
-Example:
+## Dependencies
+The macro expands to usage of `postgres-types`, so make sure to have it in your dependencies:
+```toml
+[dependencies]
+postgres-types = ...
+pg_named_args = ...
+```
+
+## Query Argument Syntax
+The macro uses struct syntax for the named arguments.
+The struct name `Args` is required to support rustfmt and rust-analyzer.
+As can be seen from the example below, shorthand field initialization is also allowed for named arguments.
 
 ```rust
+let location = "netherlands";
+let period = Period {
+    start: 2020,
+    end: 2030,
+};
+
 let (query, args) = query_args!(
     r"
     SELECT location, time, report
@@ -23,31 +42,48 @@ let (query, args) = query_args!(
         end: period.end,
     }
 );
+```
+```rust
 let rows = client.query(query, args).await?;
 ```
 
-The macro uses struct syntax for the named arguments. The struct name `Args` is required to support rustfmt and rust-analyzer.
-As can be seen from the example above, shorthand field initialization is also allowed for named arguments.
-
+## Insert Syntax
 For `INSERT`'s a special syntax is supported, which helps to avoid mismatches
 between the list of column names and the values:
 
 ```rust
+let location = "sweden";
+let time = "monday";
+let report = "sunny";
+
 let (query, args) = query_args!(
     r"
     INSERT INTO weather_reports
-        ( $[location, time, report] ) 
-    VALUES 
+        ( $[location, time, report] )
+    VALUES
         ( $[..] )
     ",
-    Args { location, time, report }
+    Args {
+        location,
+        time,
+        report
+    }
 );
+```
+```rust
 client.execute(query, args).await?;
 ```
 
-The macro is written in a way that is rust-analyzer friendly.
-This means that rust analyzer knows which parameters are required and can complete them.
-Use the code action "Fill struct fields" or ask rust analyzer to complete a field name.
+## IDE Support
+
+First, the syntax used by this macro is compatible with rustfmt.
+Run rustfmt as you would normally and it will format the macro.
+
+Second, the macro is implemented in a way that is rust-analyzer "friendly".
+This means that rust-analyzer knows which arguments are required and can complete them.
+Use the code action "Fill struct fields" or ask rust-analyzer to complete a field name.
+
+<!-- cargo-rdme end -->
 
 ## Goals
 
@@ -55,9 +91,9 @@ Use the code action "Fill struct fields" or ask rust analyzer to complete a fiel
 
 - Reduce the risk of mismatching query arguments.
 
-- Support for rust-analyzer completion and some code actions.
-
 - Support for rustfmt to help with formatting.
+
+- Support for rust-analyzer completion and some code actions.
 
 ## Contributing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,92 @@
+//! This library allows one to use named arguments in PostgreSQL queries. This
+//! library is especially aimed at supporting
+//! [rust-postgres](https://github.com/sfackler/rust-postgres). A macro is provided
+//! to rewrite queries with named arguments, into a query and its positional
+//! arguments.
+//!
+//! # Dependencies
+//! The macro expands to usage of `postgres-types`, so make sure to have it in your dependencies:
+//! ```toml
+//! [dependencies]
+//! postgres-types = ...
+//! pg_named_args = ...
+//! ```
+//!
+//! # Query Argument Syntax
+//! The macro uses struct syntax for the named arguments.
+//! The struct name `Args` is required to support rustfmt and rust-analyzer.
+//! As can be seen from the example below, shorthand field initialization is also allowed for named arguments.
+//!
+//! ```
+//! # use pg_named_args::query_args;
+//! # struct Period {
+//! #     start: u32,
+//! #     end: u32,
+//! # }
+//! #
+//! let location = "netherlands";
+//! let period = Period {
+//!     start: 2020,
+//!     end: 2030,
+//! };
+//!
+//! let (query, args) = query_args!(
+//!     r"
+//!     SELECT location, time, report
+//!     FROM weather_reports
+//!     WHERE location = $location
+//!         AND time BETWEEN $start AND $end
+//!     ORDER BY location, time DESC
+//!     ",
+//!     Args {
+//!         location,
+//!         start: period.start,
+//!         end: period.end,
+//!     }
+//! );
+//! ```
+//! ```ignore
+//! let rows = client.query(query, args).await?;
+//! ```
+//!
+//! # Insert Syntax
+//! For `INSERT`'s a special syntax is supported, which helps to avoid mismatches
+//! between the list of column names and the values:
+//!
+//! ```
+//! # use pg_named_args::query_args;
+//! #
+//! let location = "sweden";
+//! let time = "monday";
+//! let report = "sunny";
+//!
+//! let (query, args) = query_args!(
+//!     r"
+//!     INSERT INTO weather_reports
+//!         ( $[location, time, report] )
+//!     VALUES
+//!         ( $[..] )
+//!     ",
+//!     Args {
+//!         location,
+//!         time,
+//!         report
+//!     }
+//! );
+//! ```
+//! ```ignore
+//! client.execute(query, args).await?;
+//! ```
+//!
+//! # IDE Support
+//!
+//! First, the syntax used by this macro is compatible with rustfmt.
+//! Run rustfmt as you would normally and it will format the macro.
+//!
+//! Second, the macro is implemented in a way that is rust-analyzer "friendly".
+//! This means that rust-analyzer knows which arguments are required and can complete them.
+//! Use the code action "Fill struct fields" or ask rust-analyzer to complete a field name.
+
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{
@@ -10,25 +99,24 @@ use syn::{
     ExprStruct, ItemStruct, LitStr, Member, Token,
 };
 
-/// This macro implements named parameters, for use with tokio_postgres.
-///
 /// The macro returns a tuple containing the query and the parameter slice that
-/// can be used to call the various query methods provided by tokio_postgres.
+/// can be used to call the various query methods provided by rust_postgres/tokio_postgres.
+///
+/// Please refer to the crate level documentation for an overview of the syntax.
 ///
 /// A complete example could look something like:
-/// ```ignore
+/// ```
+/// # use pg_named_args::query_args;
 /// let name = "Fred";
 /// let surname = "Flintstone";
 /// let (query, params) = query_args!(
-///        r"INSERT INTO flintstone($[name, surname]) VALUES($[..])",
-///        Args { name, surname }
-///    );
+///     r"INSERT INTO flintstone($[name, surname]) VALUES($[..])",
+///     Args { name, surname }
+/// );
+/// ```
+/// ```ignore
 /// txn.execute(query, params).await?;
 /// ```
-///
-/// A number of different syntactical forms are supported see the [integration
-/// tests](https://git.service.d11n.nl/dreamsolution/tandemdrive/src/branch/main/share/proc_macros/tests/integration/main.rs) for examples.
-// #[proc_macro]
 #[proc_macro]
 pub fn query_args(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input_raw = TokenStream::from(input.clone());


### PR DESCRIPTION
I got the idea from  #8, but this approach allows testing the examples in the readme.
The readme can now also contain extra information that is not documentation.