### PR TITLE
Check that struct update syntax is not used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_named_args"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/tandemdrive/pg_named_args"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,13 @@ pub fn query_args(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         .surround(&mut init, |init| format.args_inner.to_tokens(init));
 
     let params = if let Ok(res) = parse2::<ExprStruct>(init) {
+        if let Some(dots) = res.dot2_token {
+            errors.push(syn::Error::new_spanned(
+                dots,
+                "struct update syntax is not supported by the query_args macro",
+            ))
+        }
+
         let params = names
             .iter()
             .filter_map(|search| {

--- a/tests/ui/struct_update.rs
+++ b/tests/ui/struct_update.rs
@@ -1,0 +1,13 @@
+use pg_named_args::query_args;
+
+fn main() {
+    let _: (_, &[u32]) = query_args!(
+        "$a, $b",
+        Args {
+            ..Args {
+                a: "test",
+                b: "test"
+            }
+        }
+    );
+}

--- a/tests/ui/struct_update.stderr
+++ b/tests/ui/struct_update.stderr
@@ -1,0 +1,5 @@
+error: struct update syntax is not supported by the query_args macro
+ --> tests/ui/struct_update.rs:7:13
+  |
+7 |             ..Args {
+  |             ^^


### PR DESCRIPTION
Using struct update syntax would break the macro, this is now explicitly checked.
I also updated the version so that we can publish this.