### PR TITLE
New release changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_named_args"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/tandemdrive/pg_named_args"
@@ -14,7 +14,7 @@ categories = ["database"]
 members = ["pg_named_args_macros"]
 
 [dependencies]
-pg_named_args_macros = {version = "0.2.3", path = "./pg_named_args_macros"}
+pg_named_args_macros = {version = "=0.3.0", path = "./pg_named_args_macros"}
 postgres-types = "0.2.6"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = ["pg_named_args_macros"]
 
 [dependencies]
 pg_named_args_macros = {version = "0.2.3", path = "./pg_named_args_macros"}
+postgres-types = "0.2.6"
 
 [dev-dependencies]
-postgres-types = "0.2.6"
 trybuild = "1.0.89"

--- a/README.md
+++ b/README.md
@@ -74,6 +74,29 @@ let (query, args) = query_args!(
 client.execute(query, args).await?;
 ```
 
+## Fragment Syntax
+```rust
+let select = fragment!("
+    SELECT location, time, report
+    FROM weather_reports
+");
+
+let location = "sweden";
+
+let (query, args) = query_args!(
+    r"
+    ${select}
+    WHERE location = $location
+    ",
+    Args {
+        location,
+    },
+    Sql {
+        select,
+    }
+);
+```
+
 ## IDE Support
 
 First, the syntax used by this macro is compatible with rustfmt.

--- a/README.md
+++ b/README.md
@@ -8,14 +8,6 @@ library is especially aimed at supporting
 to rewrite queries with named arguments, into a query and its positional
 arguments.
 
-## Dependencies
-The macro expands to usage of `postgres-types`, so make sure to have it in your dependencies:
-```toml
-[dependencies]
-postgres-types = ...
-pg_named_args = ...
-```
-
 ## Query Argument Syntax
 The macro uses struct syntax for the named arguments.
 The struct name `Args` is required to support rustfmt and rust-analyzer.

--- a/pg_named_args_macros/Cargo.toml
+++ b/pg_named_args_macros/Cargo.toml
@@ -17,7 +17,3 @@ proc-macro = true
 proc-macro2 = "1.0.70"
 quote = "1.0.33"
 syn = { version = "2.0.41", default-features = false, features = ["clone-impls", "parsing", "printing", "proc-macro", "full"] }
-
-[dev-dependencies]
-postgres-types = "0.2.6"
-pg_named_args = {path = "../"}

--- a/pg_named_args_macros/Cargo.toml
+++ b/pg_named_args_macros/Cargo.toml
@@ -17,3 +17,6 @@ proc-macro = true
 proc-macro2 = "1.0.70"
 quote = "1.0.33"
 syn = { version = "2.0.41", default-features = false, features = ["clone-impls", "parsing", "printing", "proc-macro", "full"] }
+
+[dev-dependencies]
+pg_named_args = {path = "../"}

--- a/pg_named_args_macros/Cargo.toml
+++ b/pg_named_args_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_named_args_macros"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/tandemdrive/pg_named_args"

--- a/pg_named_args_macros/src/lib.rs
+++ b/pg_named_args_macros/src/lib.rs
@@ -341,6 +341,12 @@ impl Parse for Format {
     }
 }
 
+/// This macro creates a `Fragment` from a string literal.
+///
+/// Checking that the input is a string literal prevents accidental SQL injection with dynamic strings.
+/// The resulting `Fragment` can be used with the [query_args] macro.
+///
+/// This is useful for creating dynamic queries where fragments can be swapped out for each other.
 #[proc_macro]
 pub fn fragment(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input_raw = TokenStream::from(input.clone());

--- a/pg_named_args_macros/src/lib.rs
+++ b/pg_named_args_macros/src/lib.rs
@@ -91,7 +91,7 @@ pub fn query_args(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     // Make a reference using res.span() so that ToSql errors are shown nicely.
                     let res = quote_spanned!(res.span()=> &#res);
                     // Cast to &dyn without span to hide unnecessary cast warning
-                    quote!(#res as &(dyn ::postgres_types::ToSql + Sync))
+                    quote!(#res as &(dyn ::pg_named_args::postgres_types::ToSql + Sync))
                 })
                 .collect()
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,8 @@
 extern crate self as pg_named_args;
 
 pub use pg_named_args_macros::{fragment, query_args};
+#[doc(hidden)]
+pub use postgres_types;
 
 /// Helper type to safely build queries from string literals.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,6 @@
 //! to rewrite queries with named arguments, into a query and its positional
 //! arguments.
 //!
-//! # Dependencies
-//! The macro expands to usage of `postgres-types`, so make sure to have it in your dependencies:
-//! ```toml
-//! [dependencies]
-//! postgres-types = ...
-//! pg_named_args = ...
-//! ```
-//!
 //! # Query Argument Syntax
 //! The macro uses struct syntax for the named arguments.
 //! The struct name `Args` is required to support rustfmt and rust-analyzer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,31 @@
 //! client.execute(query, args).await?;
 //! ```
 //!
+//! # Fragment Syntax
+//! ```
+//! # use pg_named_args::{query_args, fragment};
+//! #
+//! let select = fragment!("
+//!     SELECT location, time, report
+//!     FROM weather_reports
+//! ");
+//!
+//! let location = "sweden";
+//!
+//! let (query, args) = query_args!(
+//!     r"
+//!     ${select}
+//!     WHERE location = $location
+//!     ",
+//!     Args {
+//!         location,
+//!     },
+//!     Sql {
+//!         select,
+//!     }
+//! );
+//! ```
+//!
 //! # IDE Support
 //!
 //! First, the syntax used by this macro is compatible with rustfmt.
@@ -91,10 +116,15 @@ extern crate self as pg_named_args;
 
 pub use pg_named_args_macros::{fragment, query_args};
 
+/// Helper type to safely build queries from string literals.
+///
+/// This type can be constructed using the [fragment] macro.
+/// It can then be used in [query_args] as part of the SQL statement.
 #[derive(Clone, Copy, Default)]
 pub struct Fragment(&'static str);
 
 impl Fragment {
+    /// Get the internal [str] from the [Fragment].
     pub fn get(self) -> &'static str {
         self.0
     }


### PR DESCRIPTION
Added documentation for `Fragment` and `fragment!`.
Re-exported `postgres-types` so that it does not need to be added as a dependencies by users of `pg_named_args`.
Updated the version numbers in preparation of a new release.